### PR TITLE
Fix issue #1 Change RewriteCond for wp-login.php

### DIFF
--- a/custom_import/secure_wp_htaccess
+++ b/custom_import/secure_wp_htaccess
@@ -5,7 +5,10 @@ RewriteCond  %{REQUEST_URI}  ^/wp-admin-panel$
 RewriteRule .* wp-login.php
 
 RewriteCond %{REQUEST_URI} /wp-login.php
+RewriteCond %{HTTP_REFERER} !/wp-admin-panel$
 RewriteCond %{ENV:REDIRECT_STATUS} ^$
+RewriteCond %{QUERY_STRING} !^action=logout
+RewriteCond %{QUERY_STRING} !^loggedout=true
 RewriteRule .* - [F,L]
 </IfModule>
 


### PR DESCRIPTION
This should fix issue #1.
We must authorize access to wp-login.php when "HTTP_REFERER" is "/wp-admin-panel". So users can now login without 403 error.
We also authorize access to wp-login.php when "QUERY_STRING" start with "action=logout" or "loggedout=true" so users can logout without 403.
